### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/actuarial-services/20c6bee2-a594-4d29-b108-2d9a9c9dcad1/97018906-4c60-4d6e-9afd-5a408a89bced/_apis/work/boardbadge/85ca9e55-ead1-492f-86f9-4487d1a9c013)](https://dev.azure.com/actuarial-services/20c6bee2-a594-4d29-b108-2d9a9c9dcad1/_boards/board/t/97018906-4c60-4d6e-9afd-5a408a89bced/Microsoft.EpicCategory)
 # Cloud Playbook
 
 > Documentation, notes, and workflows regarding the Cloud Infrastructure and Setup for the core hosting providers: Azure, AWS, and GCP.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#971](https://dev.azure.com/actuarial-services/20c6bee2-a594-4d29-b108-2d9a9c9dcad1/_workitems/edit/971). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.